### PR TITLE
Fix pytest failure detection

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -25818,9 +25818,10 @@ const headerRegexes = {
 }
 
 const errorRegex = /^_+ ERROR collecting (?<filePath>.*) _+$\n(^[^E_]+.*$\n)+^E\s+(?<kind>[^:\n]+):\s+(?<message>[^\n]+)$/gm
-const failureRegex = /^E\s+(?<kind>[^:\n]+):\s+(?<message>[^\n]+)$\n^\s*$\n^(?<filePath>([A-Z]:)?[^:]+):(?<line>\d+):\s+(?<kind2>[^:\n]+$)/gm
+const failureRegex = /^E\s+(?<kind>[^:\n]+)(?::\s+(?<message>[^\n]+))?$\n^\s*$\n^(?<filePath>([A-Z]:)?[^:]+):(?<line>\d+):\s+(?<kind2>[^\n]+$)/gm
 const warningRegex = /^\s*(?<filePath>([A-Z]:)?[^:]+):(?<line>\d+):(?<kind>[^:]+):(?<message>[^\n]+)\n(?<code>[^\n]+)/gm
 const tracebackLineRegex = /^\s*(?<filePath>[^\s:]+):(?<line>\d+):\s+in\s+/gm
+const summaryFailureRegex = /^(?<outcome>FAILED|ERROR) (?<nodeid>\S+)(?: - (?<detail>[^\n]+))?$/gm
 
 function parseErrorsSection (body) {
   const annotations = []
@@ -25869,7 +25870,8 @@ function parseFailuresSection (body) {
   const annotations = []
 
   for (const match of body.matchAll(failureRegex)) {
-    const { filePath, line, kind, message } = match.groups
+    const { filePath, line, kind } = match.groups
+    const message = match.groups.message || kind
 
     annotations.push({
       source: 'pytest',
@@ -25878,6 +25880,28 @@ function parseFailuresSection (body) {
       line: parseInt(line),
       kind: kind.trim(),
       message: message.trim(),
+    })
+  }
+
+  return annotations
+}
+
+function parseSummarySection (body) {
+  const annotations = []
+
+  for (const match of body.matchAll(summaryFailureRegex)) {
+    const { detail, nodeid, outcome } = match.groups
+    const filePath = nodeid.split('::')[0]
+    const message = (detail || `${outcome} ${nodeid}`).trim()
+    const kind = (detail ? detail.split(':')[0] : outcome).trim()
+
+    annotations.push({
+      source: 'pytest',
+      level: 'error',
+      filePath,
+      line: 1,
+      kind,
+      message,
     })
   }
 
@@ -25946,6 +25970,18 @@ function parsePytest (infile) {
   if (bodies.warnings) {
     annotations.push(...parseWarningsSection(
       fileContent.slice(bodies.warnings.start, bodies.warnings.end)))
+  }
+  if (bodies.summary) {
+    const summaryAnnotations = parseSummarySection(
+      fileContent.slice(bodies.summary.start, bodies.summary.end))
+    for (const summaryAnnotation of summaryAnnotations) {
+      if (!annotations.some(annotation =>
+        annotation.source === summaryAnnotation.source &&
+        annotation.level === 'error' &&
+        annotation.filePath === summaryAnnotation.filePath)) {
+        annotations.push(summaryAnnotation)
+      }
+    }
   }
 
   return annotations

--- a/src/python/pytest.js
+++ b/src/python/pytest.js
@@ -13,9 +13,10 @@ const headerRegexes = {
 
 const errorHeaderRegex = /^_+ ERROR collecting (?<filePath>.+?) _+$/gm
 const errorLineRegex = /^E\s+(?<kind>[^:\n]+):\s+(?<message>[^\n]+)$/gm
-const failureRegex = /^E\s+(?<kind>[^:\n]+):\s+(?<message>[^\n]+)$\n^\s*$\n^(?<filePath>([A-Z]:)?[^:]+):(?<line>\d+):\s+(?<kind2>[^:\n]+$)/gm
+const failureRegex = /^E\s+(?<kind>[^:\n]+)(?::\s+(?<message>[^\n]+))?$\n^\s*$\n^(?<filePath>([A-Z]:)?[^:]+):(?<line>\d+):\s+(?<kind2>[^\n]+$)/gm
 const warningRegex = /^\s*(?<filePath>([A-Z]:)?[^:]+):(?<line>\d+):(?<kind>[^:]+):(?<message>[^\n]+)\n(?<code>[^\n]+)/gm
 const tracebackLineRegex = /^\s*(?<filePath>[^\s:]+):(?<line>\d+):\s+in\s+/gm
+const summaryFailureRegex = /^(?<outcome>FAILED|ERROR) (?<nodeid>\S+)(?: - (?<detail>[^\n]+))?$/gm
 
 function parseErrorsSection (body) {
   const annotations = []
@@ -66,7 +67,8 @@ function parseFailuresSection (body) {
   const annotations = []
 
   for (const match of body.matchAll(failureRegex)) {
-    const { filePath, line, kind, message } = match.groups
+    const { filePath, line, kind } = match.groups
+    const message = match.groups.message || kind
 
     annotations.push({
       source: 'pytest',
@@ -75,6 +77,28 @@ function parseFailuresSection (body) {
       line: parseInt(line),
       kind: kind.trim(),
       message: message.trim(),
+    })
+  }
+
+  return annotations
+}
+
+function parseSummarySection (body) {
+  const annotations = []
+
+  for (const match of body.matchAll(summaryFailureRegex)) {
+    const { detail, nodeid, outcome } = match.groups
+    const filePath = nodeid.split('::')[0]
+    const message = (detail || `${outcome} ${nodeid}`).trim()
+    const kind = (detail ? detail.split(':')[0] : outcome).trim()
+
+    annotations.push({
+      source: 'pytest',
+      level: 'error',
+      filePath: normalizeFilePath(filePath),
+      line: 1,
+      kind,
+      message,
     })
   }
 
@@ -144,6 +168,18 @@ function parsePytest (infile) {
   if (bodies.warnings) {
     annotations.push(...parseWarningsSection(
       fileContent.slice(bodies.warnings.start, bodies.warnings.end)))
+  }
+  if (bodies.summary) {
+    const summaryAnnotations = parseSummarySection(
+      fileContent.slice(bodies.summary.start, bodies.summary.end))
+    for (const summaryAnnotation of summaryAnnotations) {
+      if (!annotations.some(annotation =>
+        annotation.source === summaryAnnotation.source &&
+        annotation.level === 'error' &&
+        annotation.filePath === summaryAnnotation.filePath)) {
+        annotations.push(summaryAnnotation)
+      }
+    }
   }
 
   return annotations

--- a/test/run.js
+++ b/test/run.js
@@ -152,3 +152,15 @@ runTest('dist/index.js handles pytest text output (pipescaler)', () => {
   assert.ok(output.includes('::error'))
   assert.ok(output.includes('pytest['))
 })
+
+runTest('dist/index.js handles pytest failures reported only in the short summary', () => {
+  const output = runAction(
+    'pytest',
+    fixturePath('scinoephile', 'pytest-failed-summary.txt'),
+    '/home/runner/work/Scinoephile/Scinoephile',
+  )
+
+  assert.ok(output.includes('::error'))
+  assert.ok(output.includes('file=cli/dictionary/test_dictionary_cli.py'))
+  assert.ok(output.includes('pytest[AssertionError]'))
+})

--- a/testdata/scinoephile/pytest-failed-summary.txt
+++ b/testdata/scinoephile/pytest-failed-summary.txt
@@ -1,0 +1,18 @@
+============================= test session starts ==============================
+platform linux -- Python 3.13.13, pytest-9.0.2, pluggy-1.6.0
+rootdir: /home/runner/work/Scinoephile/Scinoephile
+collected 880 items
+
+cli/dictionary/test_dictionary_cli.py::test_dictionary_usage[cli0] FAILED [100%]
+
+=================================== FAILURES ===================================
+_________________________ test_dictionary_usage[cli0] __________________________
+
+cli = <scinoephile.cli.dictionary.DictionaryCli object at 0x7f0000000000>
+
+    def test_dictionary_usage(cli):
+>       assert False
+E       AssertionError
+=========================== short test summary info ============================
+FAILED cli/dictionary/test_dictionary_cli.py::test_dictionary_usage[cli0] - AssertionError
+============ 1 failed, 879 passed, 2 warnings in 122.56s (0:02:02) ============


### PR DESCRIPTION
## Summary

Fixes pytest output parsing so LinterPrinter fails the GitHub Action when pytest reports failures that were previously only visible in the test output.

## Root Cause

Scinoephile CI captured pytest output and then relied on `KarlTDebiec/LinterPrinter@main` to emit error annotations and fail the step. The pytest parser missed bare exception lines like `E AssertionError` and could also miss failures that appeared in pytest's short summary as `FAILED ... - AssertionError`, so the action completed successfully despite pytest reporting a failed test.

## Changes

- Accept pytest failure lines without a colon-separated message, such as `E AssertionError`.
- Parse `FAILED` and `ERROR` entries from `short test summary info` as fallback error annotations.
- Avoid duplicating fallback summary annotations when the detailed failure parser already emitted an error for the same file.
- Add a Scinoephile-style regression fixture and test.
- Update `dist/index.js`, since GitHub Actions runs the packaged entrypoint.

## Validation

- Targeted repro now exits non-zero and emits `::error file=cli/dictionary/test_dictionary_cli.py,line=1::pytest[AssertionError] : AssertionError` followed by `::error::Found 1 error annotation.`
- `npm test` still exits non-zero because three pre-existing pyright fixture tests fail; the new pytest regression test passes.